### PR TITLE
sexpose prom ports in nginx-ingress-controller

### DIFF
--- a/tf-aws/modules/helm/values/nginx-ingress.yaml
+++ b/tf-aws/modules/helm/values/nginx-ingress.yaml
@@ -7,3 +7,13 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: external
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+  prometheus:
+    create: true
+    port: 9113
+    secret: ""
+    scheme: http
+    service:
+      create: true
+    serviceMonitor:
+      create: true
+      labels: { app: nginx-ingress-servicemonitor } 


### PR DESCRIPTION
this pr configures the helm values for the nic to expose ports for prometheus. 

validated the yml with `helm install nginx-ingress ingress-nginx/ingress-nginx --dry-run --debug -f nginx-ingress.yaml > test.txt`

generated test.txt matches the values.yaml according to the pic below:

<img width="941" alt="image" src="https://github.com/user-attachments/assets/92bf0063-834b-4da3-93d3-0bcec22268bb" />

taken from https://www.f5.com/company/blog/nginx/nginx-ingress-controller-with-prometheus-operator-for-out-of-the-box-metrics

