### PR TITLE
bootstrapped rds and created documentdb

### DIFF
--- a/tf-aws/main.tf
+++ b/tf-aws/main.tf
@@ -3,7 +3,7 @@ module "vpc" {
   vpc_cidr                   = "10.0.0.0/16"
   pc_mt_id                   = module.mock-server.pc_mt_id
   vpc_mock_server_cidr_block = module.mock-server.vpc_mock_server_cidr_block
-  eks_cluster_sg_id = module.eks.eks_cluster_sg_id
+  eks_cluster_sg_id          = module.eks.eks_cluster_sg_id
 }
 
 module "iam" {
@@ -128,8 +128,8 @@ module "amplify" {
 }
 
 module "docdb" {
-  source = "./modules/docdb"
-  vpc_azs = module.vpc.azs
+  source               = "./modules/docdb"
+  vpc_azs              = module.vpc.azs
   db_subnet_group_name = module.vpc.db_subnet_group_name
-  docdb_sg_id = module.vpc.docdb_sg_id
+  docdb_sg_id          = module.vpc.docdb_sg_id
 }

--- a/tf-aws/main.tf
+++ b/tf-aws/main.tf
@@ -3,6 +3,7 @@ module "vpc" {
   vpc_cidr                   = "10.0.0.0/16"
   pc_mt_id                   = module.mock-server.pc_mt_id
   vpc_mock_server_cidr_block = module.mock-server.vpc_mock_server_cidr_block
+  eks_cluster_sg_id = module.eks.eks_cluster_sg_id
 }
 
 module "iam" {
@@ -124,4 +125,11 @@ module "mock-server" {
 module "amplify" {
   source                   = "./modules/amplify"
   amplify_logging_role_arn = module.iam.amplify_logging_role_arn
+}
+
+module "docdb" {
+  source = "./modules/docdb"
+  vpc_azs = module.vpc.azs
+  db_subnet_group_name = module.vpc.db_subnet_group_name
+  docdb_sg_id = module.vpc.docdb_sg_id
 }

--- a/tf-aws/modules/docdb/data.tf
+++ b/tf-aws/modules/docdb/data.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret" "docdb_credentials" {
+  name = "docdb-credentials"
+}
+
+data "aws_secretsmanager_secret_version" "docdb_credentials" {
+  secret_id = data.aws_secretsmanager_secret.docdb_credentials.id
+}

--- a/tf-aws/modules/docdb/main.tf
+++ b/tf-aws/modules/docdb/main.tf
@@ -1,0 +1,30 @@
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "scrooge-bank-cluster"
+  engine                  = "docdb"
+  availability_zones = var.vpc_azs
+  master_username    = "test"
+  master_password    = "notrealpassword"
+  db_subnet_group_name = var.db_subnet_group_name
+  engine_version = "5.0.0"
+
+  skip_final_snapshot           = true
+#   skip_final_snapshot           = false
+#   final_snapshot_identifier     = "main-docdb-cluster-${replace(timestamp(), ":", "-")}"
+#   snapshot_identifier           = "has-mock-data"
+#   backup_retention_period       = 5
+#   preferred_backup_window       = "07:00-09:00"
+  storage_encrypted = true
+  storage_type = "standard"
+  vpc_security_group_ids = [var.docdb_sg_id]
+
+  tags = {
+    "Name" = "scrooge-bank-docdb"
+  }
+}
+
+resource "aws_docdb_cluster_instance" "cluster_instances" {
+  count              = 2
+  identifier         = "scrooge-bank-cluster-${count.index}"
+  cluster_identifier = aws_docdb_cluster.default.id
+  instance_class     = "db.t4g.medium"
+}

--- a/tf-aws/modules/docdb/main.tf
+++ b/tf-aws/modules/docdb/main.tf
@@ -1,20 +1,20 @@
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier = "scrooge-bank-cluster"
-  engine                  = "docdb"
-  availability_zones = var.vpc_azs
-  master_username    = "test"
-  master_password    = "notrealpassword"
+  cluster_identifier   = "scrooge-bank-cluster"
+  engine               = "docdb"
+  availability_zones   = var.vpc_azs
+  master_username      = jsondecode(data.aws_secretsmanager_secret_version.docdb_credentials.secret_string)["username"]
+  master_password      = jsondecode(data.aws_secretsmanager_secret_version.docdb_credentials.secret_string)["password"]
   db_subnet_group_name = var.db_subnet_group_name
-  engine_version = "5.0.0"
+  engine_version       = "5.0.0"
 
-  skip_final_snapshot           = true
-#   skip_final_snapshot           = false
-#   final_snapshot_identifier     = "main-docdb-cluster-${replace(timestamp(), ":", "-")}"
-#   snapshot_identifier           = "has-mock-data"
-#   backup_retention_period       = 5
-#   preferred_backup_window       = "07:00-09:00"
-  storage_encrypted = true
-  storage_type = "standard"
+  skip_final_snapshot = true
+  #   skip_final_snapshot           = false
+  #   final_snapshot_identifier     = "main-docdb-cluster-${replace(timestamp(), ":", "-")}"
+  #   snapshot_identifier           = "has-mock-data"
+  #   backup_retention_period       = 5
+  #   preferred_backup_window       = "07:00-09:00"
+  storage_encrypted      = true
+  storage_type           = "standard"
   vpc_security_group_ids = [var.docdb_sg_id]
 
   tags = {

--- a/tf-aws/modules/docdb/outputs.tf
+++ b/tf-aws/modules/docdb/outputs.tf
@@ -3,9 +3,9 @@ output "docdb_cluster_arn" {
 }
 
 output "docdb_cluster_endpoint" {
-    value = aws_docdb_cluster.default.endpoint
+  value = aws_docdb_cluster.default.endpoint
 }
 
 output "docdb_cluster_id" {
-    value = aws_docdb_cluster.default.id
+  value = aws_docdb_cluster.default.id
 }

--- a/tf-aws/modules/docdb/outputs.tf
+++ b/tf-aws/modules/docdb/outputs.tf
@@ -1,0 +1,11 @@
+output "docdb_cluster_arn" {
+  value = aws_docdb_cluster.default.arn
+}
+
+output "docdb_cluster_endpoint" {
+    value = aws_docdb_cluster.default.endpoint
+}
+
+output "docdb_cluster_id" {
+    value = aws_docdb_cluster.default.id
+}

--- a/tf-aws/modules/docdb/variables.tf
+++ b/tf-aws/modules/docdb/variables.tf
@@ -1,0 +1,5 @@
+variable "vpc_azs" {}
+
+variable "db_subnet_group_name" {}
+
+variable "docdb_sg_id" {}

--- a/tf-aws/modules/iam/main.tf
+++ b/tf-aws/modules/iam/main.tf
@@ -415,9 +415,9 @@ data "aws_iam_policy_document" "bastion_rds_policy" {
 }
 
 resource "aws_iam_policy" "bastion_rds_policy" {
-  name = "bastion_rds_policy"
+  name        = "bastion_rds_policy"
   description = "policy for bastion to reach rds"
-  policy = data.aws_iam_policy_document.bastion_rds_policy.json
+  policy      = data.aws_iam_policy_document.bastion_rds_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "bastion_rds_policy_attachment" {

--- a/tf-aws/modules/iam/main.tf
+++ b/tf-aws/modules/iam/main.tf
@@ -382,6 +382,48 @@ resource "aws_iam_instance_profile" "bastion_profile" {
   role = aws_iam_role.bastion_role.name
 }
 
+data "aws_iam_policy_document" "bastion_rds_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds-db:connect"
+    ]
+    resources = [
+      var.rds_cluster_arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = [
+      var.aurora_kms_key_arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [
+      var.rds_cluster_secret_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bastion_rds_policy" {
+  name = "bastion_rds_policy"
+  description = "policy for bastion to reach rds"
+  policy = data.aws_iam_policy_document.bastion_rds_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_rds_policy_attachment" {
+  role       = aws_iam_role.bastion_role.name
+  policy_arn = aws_iam_policy.bastion_rds_policy.arn
+}
 
 # Transfer Family roles
 resource "aws_iam_role" "transfer_logging_role" {

--- a/tf-aws/modules/rds-aurora/main.tf
+++ b/tf-aws/modules/rds-aurora/main.tf
@@ -4,7 +4,7 @@ resource "aws_rds_cluster" "main" {
   availability_zones            = ["ap-southeast-1a", "ap-southeast-1b"]
   database_name                 = "user_db" # (optional) name of automatically created database on cluster creation
   manage_master_user_password   = true
-  master_username               = "test"
+  master_username               = "postgres"
   master_user_secret_kms_key_id = var.aurora_kms_key_id
   skip_final_snapshot           = false
   final_snapshot_identifier     = "main-rds-cluster-${replace(timestamp(), ":", "-")}"

--- a/tf-aws/modules/rds-aurora/main.tf
+++ b/tf-aws/modules/rds-aurora/main.tf
@@ -8,7 +8,7 @@ resource "aws_rds_cluster" "main" {
   master_user_secret_kms_key_id = var.aurora_kms_key_id
   skip_final_snapshot           = false
   final_snapshot_identifier     = "main-rds-cluster-${replace(timestamp(), ":", "-")}"
-  snapshot_identifier           = "scrooge-bank-prod-v1"
+  snapshot_identifier           = "scrooge-bank-prod-v2"
   backup_retention_period       = 5
   preferred_backup_window       = "07:00-09:00"
   # apply_immediately      = true

--- a/tf-aws/modules/rds-aurora/main.tf
+++ b/tf-aws/modules/rds-aurora/main.tf
@@ -4,7 +4,7 @@ resource "aws_rds_cluster" "main" {
   availability_zones            = ["ap-southeast-1a", "ap-southeast-1b"]
   database_name                 = "user_db" # (optional) name of automatically created database on cluster creation
   manage_master_user_password   = true
-  master_username               = "postgres"
+  master_username               = "test"
   master_user_secret_kms_key_id = var.aurora_kms_key_id
   skip_final_snapshot           = false
   final_snapshot_identifier     = "main-rds-cluster-${replace(timestamp(), ":", "-")}"

--- a/tf-aws/modules/rds-aurora/main.tf
+++ b/tf-aws/modules/rds-aurora/main.tf
@@ -8,7 +8,7 @@ resource "aws_rds_cluster" "main" {
   master_user_secret_kms_key_id = var.aurora_kms_key_id
   skip_final_snapshot           = false
   final_snapshot_identifier     = "main-rds-cluster-${replace(timestamp(), ":", "-")}"
-  snapshot_identifier           = "scrooge-bank-prod-v2"
+  snapshot_identifier           = "scrooge-bank-prod-v3"
   backup_retention_period       = 5
   preferred_backup_window       = "07:00-09:00"
   # apply_immediately      = true

--- a/tf-aws/modules/rds-aurora/main.tf
+++ b/tf-aws/modules/rds-aurora/main.tf
@@ -8,20 +8,20 @@ resource "aws_rds_cluster" "main" {
   master_user_secret_kms_key_id = var.aurora_kms_key_id
   skip_final_snapshot           = false
   final_snapshot_identifier     = "main-rds-cluster-${replace(timestamp(), ":", "-")}"
-  snapshot_identifier           = "has-mock-data"
+  snapshot_identifier           = "scrooge-bank-prod-v1"
   backup_retention_period       = 5
   preferred_backup_window       = "07:00-09:00"
   # apply_immediately      = true
   db_subnet_group_name   = var.db_subnet_group_name
   storage_encrypted      = true
   vpc_security_group_ids = [var.rds_sg_id]
-  lifecycle {
-    ignore_changes = [
-      final_snapshot_identifier,
-      cluster_identifier,
-      availability_zones,
-    ]
-  }
+  # lifecycle {
+  #   ignore_changes = [
+  #     final_snapshot_identifier,
+  #     cluster_identifier,
+  #     availability_zones,
+  #   ]
+  # }
 }
 
 resource "aws_rds_cluster_instance" "main" {

--- a/tf-aws/modules/vpc/outputs.tf
+++ b/tf-aws/modules/vpc/outputs.tf
@@ -61,3 +61,7 @@ output "db_subnet_group_subnet_ids" {
 output "db_proxy_sg_id" {
   value = aws_security_group.db_proxy_sg.id
 }
+
+output "docdb_sg_id" {
+  value = aws_security_group.docdb_sg.id
+}

--- a/tf-aws/modules/vpc/sg.tf
+++ b/tf-aws/modules/vpc/sg.tf
@@ -143,17 +143,19 @@ resource "aws_security_group" "vpc_endpoint_security_group" {
 resource "aws_security_group" "docdb_sg" {
   vpc_id = aws_vpc.vpc.id
   name = "documentdb to be accessed by eks"
+}
 
-  ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = -1
-    security_groups = [var.eks_cluster_sg_id]
-  }
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_vpc_security_group_ingress_rule" "ingress_docdb" {
+    security_group_id = aws_security_group.docdb_sg.id
+  referenced_security_group_id = var.eks_cluster_sg_id
+    from_port       = 27017
+    to_port         = 27017
+    ip_protocol        = "tcp"
+}
+
+# Allow all outbound from bastion
+resource "aws_vpc_security_group_egress_rule" "egress_docdb" {
+  security_group_id = aws_security_group.docdb_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
 }

--- a/tf-aws/modules/vpc/sg.tf
+++ b/tf-aws/modules/vpc/sg.tf
@@ -142,15 +142,15 @@ resource "aws_security_group" "vpc_endpoint_security_group" {
 
 resource "aws_security_group" "docdb_sg" {
   vpc_id = aws_vpc.vpc.id
-  name = "documentdb to be accessed by eks"
+  name   = "documentdb to be accessed by eks"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ingress_docdb" {
-    security_group_id = aws_security_group.docdb_sg.id
+  security_group_id            = aws_security_group.docdb_sg.id
   referenced_security_group_id = var.eks_cluster_sg_id
-    from_port       = 27017
-    to_port         = 27017
-    ip_protocol        = "tcp"
+  from_port                    = 27017
+  to_port                      = 27017
+  ip_protocol                  = "tcp"
 }
 
 # Allow all outbound from bastion

--- a/tf-aws/modules/vpc/variables.tf
+++ b/tf-aws/modules/vpc/variables.tf
@@ -13,3 +13,6 @@ variable "vpc_mock_server_cidr_block" {
   type        = string
   default     = "10.1.0.0/16"
 }
+
+variable "eks_cluster_sg_id" {
+}


### PR DESCRIPTION
first it was the security group
then it was the iam
then it takes takes fkin 30min just to destroy and provision to retest 
and postgres user idk why doesn't want to get created so i had to create it manually

Once this terrafom is merged, the rds when provisioned should contain all the databases with fake data
- snapshot identifier is [scrooge-bank-prod-v1](https://ap-southeast-1.console.aws.amazon.com/rds/home?region=ap-southeast-1#db-snapshot:engine=aurora-postgresql;id=scrooge-bank-prod-v1)
- each time you destroy the cluster, a new snapshot is created based on the timestamp
- change the field `snapshot_identifier` if you want to use a different snapshot

